### PR TITLE
fix: do not persist OAuth refresh tokens to disk; restrict accounts file to owner-only permissions

### DIFF
--- a/src/client/java/aurick/opsec/mod/accounts/AccountManager.java
+++ b/src/client/java/aurick/opsec/mod/accounts/AccountManager.java
@@ -371,7 +371,7 @@ public class AccountManager {
     public void save() {
         try {
             JsonObject json = new JsonObject();
-            
+
             JsonArray accountsArray = new JsonArray();
             for (Account account : accounts) {
                 accountsArray.add(account.toJson());
@@ -379,17 +379,37 @@ public class AccountManager {
             json.add("accounts", accountsArray);
 
             json.addProperty("activeAccountUuid", activeAccountUuid != null ? activeAccountUuid : "");
-            
+
             // Write atomically using temp file
             Files.createDirectories(ACCOUNTS_PATH.getParent());
             Path tempFile = ACCOUNTS_PATH.resolveSibling(ACCOUNTS_PATH.getFileName() + ".tmp");
-            Files.writeString(tempFile, GSON.toJson(json));
-            Files.move(tempFile, ACCOUNTS_PATH, 
+            Files.deleteIfExists(tempFile);
+            String content = GSON.toJson(json);
+
+            // On POSIX systems (Linux/macOS), create the temp file with owner-only read/write
+            // permissions (0600) before writing. Without this, Files.writeString() inherits
+            // the process umask (typically 0644 = world-readable), which exposes tokens to
+            // every local user on a multi-user system. ATOMIC_MOVE then transfers these
+            // permissions to the final file, replacing any old 0644 file on first save.
+            try {
+                Files.createFile(tempFile,
+                    java.nio.file.attribute.PosixFilePermissions.asFileAttribute(
+                        java.nio.file.attribute.PosixFilePermissions.fromString("rw-------")));
+                Files.writeString(tempFile, content,
+                    java.nio.file.StandardOpenOption.WRITE,
+                    java.nio.file.StandardOpenOption.TRUNCATE_EXISTING);
+            } catch (UnsupportedOperationException e) {
+                // Non-POSIX (Windows): %APPDATA% directory ACLs restrict access to the
+                // current OS user, so default permissions are acceptable there.
+                Files.writeString(tempFile, content);
+            }
+
+            Files.move(tempFile, ACCOUNTS_PATH,
                     java.nio.file.StandardCopyOption.REPLACE_EXISTING,
                     java.nio.file.StandardCopyOption.ATOMIC_MOVE);
-            
+
             Opsec.LOGGER.debug("[OpSec] Saved {} accounts", accounts.size());
-            
+
         } catch (IOException e) {
             Opsec.LOGGER.error("[OpSec] Failed to save accounts: {}", e.getMessage());
         }

--- a/src/client/java/aurick/opsec/mod/accounts/SessionAccount.java
+++ b/src/client/java/aurick/opsec/mod/accounts/SessionAccount.java
@@ -821,9 +821,11 @@ public class SessionAccount implements Account {
         JsonObject json = new JsonObject();
         json.addProperty("type", "session");
         json.addProperty("accessToken", accessToken);
-        if (refreshToken != null && !refreshToken.isBlank()) {
-            json.addProperty("refreshToken", refreshToken);
-        }
+        // refreshToken is intentionally NOT written to disk.
+        // It is a long-lived Microsoft OAuth credential (valid up to 90 days) that can
+        // be used to re-derive Minecraft access tokens indefinitely. Persisting it means
+        // a single file read gives an attacker permanent account access. The token is
+        // kept in memory for the current session only and discarded on exit.
         json.addProperty("username", username);
         json.addProperty("uuid", uuid);
         json.addProperty("lastValidated", lastValidated);

--- a/src/client/java/aurick/opsec/mod/config/OpsecConfigScreen.java
+++ b/src/client/java/aurick/opsec/mod/config/OpsecConfigScreen.java
@@ -1,6 +1,7 @@
 package aurick.opsec.mod.config;
 
 import aurick.opsec.mod.Opsec;
+import aurick.opsec.mod.PrivacyLogger;
 import aurick.opsec.mod.accounts.AccountManager;
 import aurick.opsec.mod.accounts.Account;
 import aurick.opsec.mod.accounts.SessionAccount;
@@ -617,8 +618,11 @@ public class OpsecConfigScreen extends Screen {
                 String json = AccountManager.getInstance().exportToJson();
                 Files.write(file.toPath(), json.getBytes(StandardCharsets.UTF_8),
                     StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-                    
-                Opsec.LOGGER.info("[OpSec] Exported accounts to {}", file.getPath());
+
+                Opsec.LOGGER.warn("[OpSec] Exported accounts to {} — file contains session tokens, do not share it", file.getName());
+                Minecraft.getInstance().execute(() ->
+                    PrivacyLogger.sendMessage(PrivacyLogger.AlertType.WARNING,
+                        "Accounts exported. File contains session tokens — do not share it."));
             } catch (Exception e) {
                 Opsec.LOGGER.error("[OpSec] Failed to export accounts: {}", e.getMessage());
             }
@@ -769,7 +773,8 @@ public class OpsecConfigScreen extends Screen {
             
             this.exportButton = Button.builder(Component.literal("Export"), btn -> onExport.run())
                     .size(100, 20)
-                    .tooltip(Tooltip.create(Component.literal("Export accounts to JSON file")))
+                    .tooltip(Tooltip.create(Component.literal(
+                        "Export accounts to JSON file\n§cContains session tokens — do not share")))
                     .build();
         }
         


### PR DESCRIPTION
## Summary

- **Remove refresh token from disk persistence** (`SessionAccount.toJson()`): Microsoft OAuth refresh tokens are valid for up to 90 days and can re-derive full Minecraft access indefinitely. Writing them to `opsec-accounts.json` means a single file read gives an attacker permanent account control. The token is now kept in memory for the current session only. `fromJson()` still reads tokens from existing files on first load (migration path) but they are never written back after the first save.
- **Restrict `opsec-accounts.json` to owner-only permissions** (`AccountManager.save()`): `Files.writeString()` inherits the process umask, which is typically `0644` (world-readable) on Linux. The save path now creates the temp file with explicit `0600` (`rw-------`) permissions on POSIX systems before writing, then renames it atomically. Falls back to default permissions on Windows where `%APPDATA%` directory ACLs provide equivalent isolation.
- **Add export warning** (`OpsecConfigScreen`): The export dialog tooltip and a post-export chat message now explicitly warn that the exported file contains session tokens and should not be shared.

## Attack scenario mitigated

On a multi-user Linux system (e.g. a shared server), any local user could read `~/.minecraft/config/opsec-accounts.json` and extract a valid refresh token. Using the same MS → Xbox → XSTS → Minecraft auth chain already implemented in `SessionAccount`, they could silently log in as the victim at any point within the token's 90-day validity window — no password, no 2FA, no notification to the victim.

Or an attacker could use a malicious mod to read the file

## Test plan

- [ ] Add a Microsoft account, restart the client — confirm `opsec-accounts.json` contains no `refreshToken` field
- [ ] Verify the file is created with `0600` permissions on Linux (`ls -la ~/.minecraft/config/opsec-accounts.json`)
- [ ] Confirm re-login still works within the same session (refresh token retained in memory)
- [ ] Check that legacy files with a `refreshToken` field load correctly on first launch and are migrated on save
- [ ] Verify export tooltip shows the security warning
- [ ] Verify a warning message appears in chat after exporting accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)